### PR TITLE
fix(nonce): caché de nonces atascado tras BadNonce concurrente (address bloqueada)

### DIFF
--- a/docs/RECEIPT-FALLO-INTERNO.md
+++ b/docs/RECEIPT-FALLO-INTERNO.md
@@ -1,0 +1,105 @@
+# Cómo el RelaySigner reporta el fallo de la llamada interna (status=1 → fallida)
+
+> **Pregunta:** ¿`gas-management` controla el caso en que la tx externa se mina con `status=1`
+> pero la **transacción interna falla**, y devuelve la tx al cliente como **fallida** en vez de
+> como exitosa?
+>
+> **Respuesta: Sí.** El RelaySigner reescribe el resultado a fallido antes de devolverlo al
+> cliente (`eth_getTransactionReceipt` → `status=0`), y además expone un endpoint dedicado
+> (`relay_getMetaTxResult`) con el detalle estructurado.
+
+Aplica al **modelo clásico (RelayHub / `TxRelay`)**. Disponible en la rama **`develop`** (fixes de
+observabilidad: commits `fc7774e`, `d24b40d`, `5b7a3a7`).
+
+---
+
+## El problema de raíz (en el contrato, no en el signer)
+
+El RelayHub (`TxRelay`) **no revierte** ante el fallo de la llamada interna: la ejecuta con un
+`.call` de bajo nivel, captura el fallo como `executed=false`, emite
+`TransactionRelayed(..., executed=false, output)` y termina con éxito. Por eso **en besu la tx
+externa se mina con `status=1`** aunque la operación del usuario haya revertido. Es intencional: si
+revirtiera, se haría rollback del nonce y de la contabilidad de gas del nodo.
+
+Resultado: un cliente "ingenuo" (`tx.wait()` mirando solo el `status`) daría la tx por exitosa →
+**fallo silencioso**. El RelaySigner cierra ese hueco traduciendo el resultado interno al cliente.
+
+## Mecanismo 1 — `eth_getTransactionReceipt` reescribe `status=1` → `status=0`
+
+`service/relaySignerService.go` → `GetTransactionReceipt` (≈ líneas 121-198). Ruteado desde
+`controller/relayController.go` (`IsGetTransactionReceipt`) → `processGetTransactionReceipt`.
+
+Flujo:
+
+1. Pide el receipt a besu (`NodeURL`) — viene con `status=1`.
+2. Recorre `receipt.Logs` y calcula los topics (keccak) de los eventos del RelayHub.
+3. Según lo que encuentre:
+   - **`TransactionRelayed(executed=false)`** → `receipt.Status = uint64(0)` y añade
+     `revertReason` con el motivo decodificado (`decodeRevertReason(output)`).
+   - **`BadTransactionSent`** → `receipt.Status = uint64(0)` y
+     `revertReason = "BadTransactionSent: <errorCode>"`.
+   - **`ContractDeployed`** → fija `receipt.ContractAddress` con la dirección real (el receipt de
+     besu trae `0x0` porque el `CREATE` lo hace el RelayHub).
+4. Si hubo fallo, devuelve el receipt modificado (`receiptReverted`, con el campo extra
+   `revertReason`); si no, el receipt tal cual.
+
+**Efecto en el cliente:** recibe `status=0` → ethers/web3 lo tratan como transacción **revertida**,
+y `revertReason` lleva el motivo legible. La tx se devuelve como **fallida**, no como éxito.
+
+## Mecanismo 2 — endpoint `relay_getMetaTxResult` (resultado estructurado)
+
+`service/relaySignerService.go` → `GetMetaTxResult` (≈ líneas 202-263). Ruteado desde
+`controller/relayController.go` (`IsGetMetaTxResult`) → `processGetMetaTxResult`. Sufijo RPC
+`_getMetaTxResult` (`rpc/json.go`).
+
+Devuelve un objeto explícito a partir de los mismos eventos:
+
+```json
+{
+  "transactionHash": "0x…",
+  "mined": true,
+  "success": false,
+  "executed": false,
+  "errorCode": null,
+  "revertReason": "ERC20InsufficientBalance(…)",
+  "deployedAddress": null
+}
+```
+
+- `success/executed=false` + `revertReason` cuando `TransactionRelayed(executed=false)`.
+- `success=false`, `errorCode`, `revertReason="BadTransactionSent: …"` cuando `BadTransactionSent`.
+- `deployedAddress` cuando `ContractDeployed`.
+
+Es la vía recomendada para clientes que quieran el resultado lógico sin reinterpretar el `status`.
+
+## Funciones de apoyo
+
+- `transactionRelayedFailed(id, data)` (≈ línea 393) — desempaqueta el evento `TransactionRelayed`
+  y devuelve `(executed, output)`.
+- `decodeRevertReason(output)` — traduce el `output` (revert ABI-encoded; OZ v5 usa custom errors)
+  a texto legible, usando el catálogo de custom errors añadido en `5b7a3a7`.
+- `badTransactionErrorCode` / `errorCodeName` — mapean el `errorCode` del enum `IRelayHub.ErrorCode`
+  a nombre (`BadNonce`, `NotEnoughGas`, `InvalidSignature`, …).
+
+## Límites / cosas a tener en cuenta
+
+1. **Solo aplica si el cliente consulta a través de este RelaySigner.** La tx en besu sigue siendo
+   `status=1`. Quien lea el receipt desde **besu directo**, el **explorer**, u otro **RelaySigner sin
+   este parche / versión vieja** verá `status=1` (fallo silencioso). La defensa robusta e
+   independiente del signer es validar los **eventos** del lado cliente (ver el helper
+   `assertRelayedOk` en el repo `erc20-upgradeable-gas-model-erros`).
+2. **Versión:** está en `develop`, no en `master`. El nodo debe correr esta build para que aplique
+   (PR `develop`→`master` pendiente). Verificar la versión desplegada en el nodo.
+3. **Cobertura:** cubre `TransactionRelayed(executed=false)` y `BadTransactionSent`. **No** cubre el
+   síntoma *timeout en despliegues* (ahí el problema no es el `status` sino que ethers calcula la
+   dirección con `keccak(deployer,nonce)`, que no aplica bajo el gas model).
+
+## Referencias de código
+
+| Qué | Dónde |
+|---|---|
+| Reescritura de `status` en el receipt | `service/relaySignerService.go` → `GetTransactionReceipt` (≈121-198) |
+| Resultado estructurado | `service/relaySignerService.go` → `GetMetaTxResult` (≈202-263) |
+| Ruteo de los métodos | `controller/relayController.go`, `controller/processController.go`, `rpc/json.go` |
+| Por qué `relayMetaTx` no revierte | contrato `model-gas-lnet/contracts/TxRelay.sol` (`relayMetaTx`, `_executeCall`) |
+| Helper de cliente (independiente del parche) | `erc20-upgradeable-gas-model-erros/helpers/relayhub.js` (`assertRelayedOk`) |

--- a/model/Config.go
+++ b/model/Config.go
@@ -11,6 +11,9 @@ type ApplicationConfig struct {
 	NodeAddressPath         string          `mapstructure:"nodeAddressPath"`
 	Key                     string          `mapstructure:"key"`
 	Port                    string          `mapstructure:"port"`
+	// NonceCacheTTL: vida máxima (segundos) de una entrada del caché de nonces por sender.
+	// 0 o ausente = default (300s).
+	NonceCacheTTL int64 `mapstructure:"nonceCacheTTL"`
 }
 
 type KeyStoreConfig struct {

--- a/service/relaySignerService.go
+++ b/service/relaySignerService.go
@@ -40,11 +40,20 @@ var GAS_LIMIT uint64 = 0
 
 var lock sync.Mutex
 
+// nonceEntry es una entrada del caché de nonces por sender: el PRÓXIMO nonce a usar y cuándo se
+// actualizó. `updatedAt` permite expirar entradas obsoletas (TTL) y volver a leer el nonce real
+// on-chain (getNonce del RelayHub) si el caché quedara desincronizado por cualquier causa.
+type nonceEntry struct {
+	next      uint64
+	updatedAt time.Time
+}
+
 // RelaySignerService is the main service
 type RelaySignerService struct {
 	// The service's configuration
-	Config  *model.Config
-	senders map[string]*big.Int
+	Config      *model.Config
+	senders     map[string]*nonceEntry
+	sendersLock sync.Mutex
 }
 
 // Init configuration parameters
@@ -69,7 +78,7 @@ func (service *RelaySignerService) Init(_config *model.Config) error {
 
 	service.Config.Application.Key = string(key[2:66])
 
-	service.senders = make(map[string]*big.Int)
+	service.senders = make(map[string]*nonceEntry)
 
 	if service.Config.Security.PermissionsEnabled {
 		if !(common.IsHexAddress(service.Config.Security.AccountContractAddress)) {
@@ -179,7 +188,10 @@ func (service *RelaySignerService) GetTransactionReceipt(id json.RawMessage, tra
 				}
 			case "0x" + eventBadTransaction:
 				sawBadTransaction = true
-				errorCode := badTransactionErrorCode(id, log.Data)
+				errorCode, badSender := badTransactionErrorCode(id, log.Data)
+				// La meta-tx no consumió nonce en el RelayHub: descartar el contador local del
+				// sender para que su próxima lectura "pending" vuelva al nonce real on-chain.
+				service.invalidateNonce(badSender.Hex())
 				receipt.Status = uint64(0)
 
 				jsonReceipt, err := json.Marshal(receipt)
@@ -279,7 +291,8 @@ func (service *RelaySignerService) GetMetaTxResult(id json.RawMessage, transacti
 				}
 			case eventBadTransaction:
 				sawBadTransaction = true
-				code := badTransactionErrorCode(id, lg.Data)
+				code, badSender := badTransactionErrorCode(id, lg.Data)
+				service.invalidateNonce(badSender.Hex())
 				out["success"] = false
 				out["executed"] = false
 				out["errorCode"] = errorCodeName(code)
@@ -307,9 +320,12 @@ func (service *RelaySignerService) GetMetaTxResult(id json.RawMessage, transacti
 // GetTransactionCount of account
 func (service *RelaySignerService) GetTransactionCount(id json.RawMessage, from string, isPending bool) *rpc.JsonrpcMessage {
 	var count *big.Int
-	if isPending && (service.senders[from] != nil) {
-		count = service.senders[from]
-	} else {
+	if isPending {
+		if next, ok := service.cachedNonce(from); ok {
+			count = new(big.Int).SetUint64(next)
+		}
+	}
+	if count == nil {
 		client := new(bl.Client)
 		err := client.Connect(service.Config.Application.NodeURL)
 		if err != nil {
@@ -455,8 +471,9 @@ func transactionRelayedFailed(id json.RawMessage, data []byte) (bool, []byte) {
 	return transactionRelayedEvent.Executed, transactionRelayedEvent.Output
 }
 
-// badTransactionErrorCode decodifica el evento BadTransactionSent y devuelve su ErrorCode.
-func badTransactionErrorCode(id json.RawMessage, data []byte) uint8 {
+// badTransactionErrorCode decodifica el evento BadTransactionSent y devuelve su ErrorCode y el
+// originalSender afectado (para invalidar su entrada en el caché de nonces).
+func badTransactionErrorCode(id json.RawMessage, data []byte) (uint8, common.Address) {
 	var badTransactionEvent struct {
 		Node           common.Address
 		OriginalSender common.Address
@@ -473,7 +490,7 @@ func badTransactionErrorCode(id json.RawMessage, data []byte) uint8 {
 		HandleError(id, err)
 	}
 
-	return badTransactionEvent.ErrorCode
+	return badTransactionEvent.ErrorCode, badTransactionEvent.OriginalSender
 }
 
 // decodeRevertReason traduce el `output` de un revert a un string legible.
@@ -676,13 +693,64 @@ func decrement() {
 	log.GeneralLogger.Println("gas limit was reseted to 0")
 }
 
-func (service *RelaySignerService) incrementTransactionCount(from string, nonce uint64) {
-	if service.senders[from] != nil {
-		newNonce := service.senders[from].Uint64() + 1
-		service.senders[from].SetUint64(newNonce)
-	} else {
-		service.senders[from] = new(big.Int).SetUint64(nonce)
+// senderKey normaliza la clave del caché de nonces. La misma address llega en distinto case según
+// el camino: `eth_getTransactionCount` trae la string cruda del cliente (ethers la manda lowercase)
+// y la escritura interna usa `message.From().Hex()` (checksum EIP-55); sin normalizar se crean
+// entradas duplicadas que leen/escriben estados distintos.
+func senderKey(from string) string {
+	return strings.ToLower(from)
+}
+
+// nonceCacheTTL es la vida máxima de una entrada del caché (config `nonceCacheTTL` en segundos,
+// default 300). Pasado el TTL la entrada se descarta y se vuelve al nonce real on-chain: es la red
+// de seguridad si el caché diverge y el cliente nunca consulta el receipt de la tx fallida.
+func (service *RelaySignerService) nonceCacheTTL() time.Duration {
+	if service.Config != nil && service.Config.Application.NonceCacheTTL > 0 {
+		return time.Duration(service.Config.Application.NonceCacheTTL) * time.Second
 	}
+	return 300 * time.Second
+}
+
+// cachedNonce devuelve el próximo nonce cacheado para `from`, si existe y no expiró.
+func (service *RelaySignerService) cachedNonce(from string) (uint64, bool) {
+	service.sendersLock.Lock()
+	defer service.sendersLock.Unlock()
+	key := senderKey(from)
+	entry := service.senders[key]
+	if entry == nil {
+		return 0, false
+	}
+	if time.Since(entry.updatedAt) > service.nonceCacheTTL() {
+		delete(service.senders, key)
+		return 0, false
+	}
+	return entry.next, true
+}
+
+// invalidateNonce borra la entrada cacheada de `from`: la próxima lectura "pending" releerá el
+// nonce real on-chain. Se llama al detectar BadTransactionSent en el receipt — esa tx NO consumió
+// nonce en el RelayHub, así que el contador local quedó por delante del real y no puede corregirse
+// solo (cada reintento lo alejaría +1 más, dejando la address bloqueada hasta reiniciar el servicio).
+func (service *RelaySignerService) invalidateNonce(from string) {
+	service.sendersLock.Lock()
+	defer service.sendersLock.Unlock()
+	delete(service.senders, senderKey(from))
+	log.GeneralLogger.Println("nonce cache invalidated for sender:", from)
+}
+
+// incrementTransactionCount registra que `from` acaba de relayar una tx firmada con `nonce`: el
+// próximo a usar es al menos nonce+1. Si el caché ya iba más adelante (otras tx en vuelo) se
+// conserva; NO se suma +1 a ciegas — dos envíos que firmaron el MISMO nonce (colisión) solo pueden
+// consumir uno on-chain, y el +1 incondicional dejaba el contador por delante del real para siempre.
+func (service *RelaySignerService) incrementTransactionCount(from string, nonce uint64) {
+	service.sendersLock.Lock()
+	defer service.sendersLock.Unlock()
+	key := senderKey(from)
+	next := nonce + 1
+	if entry := service.senders[key]; entry != nil && time.Since(entry.updatedAt) <= service.nonceCacheTTL() && entry.next > next {
+		next = entry.next
+	}
+	service.senders[key] = &nonceEntry{next: next, updatedAt: time.Now()}
 }
 
 // HandleError

--- a/service/relaySignerService_test.go
+++ b/service/relaySignerService_test.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/LACNetNetworks/gas-relay-signer/model"
 	"github.com/LACNetNetworks/gas-relay-signer/rpc"
@@ -142,8 +143,8 @@ func TestGetTransactionCountPending(t *testing.T) {
 	config := model.Config{Application: applicationConfig}
 	relaySignerService := new(RelaySignerService)
 	_ = relaySignerService.Init(&config)
-	relaySignerService.senders = make(map[string]*big.Int)
-	relaySignerService.senders["0x92c9885663f6e84127c857d3137936c424b7e07555d2bc7d8bd781b3f0847ac8"] = new(big.Int).SetUint64(200)
+	relaySignerService.senders = make(map[string]*nonceEntry)
+	relaySignerService.senders["0x92c9885663f6e84127c857d3137936c424b7e07555d2bc7d8bd781b3f0847ac8"] = &nonceEntry{next: 200, updatedAt: time.Now()}
 	jsonResponse := relaySignerService.GetTransactionCount(rpcMessage.ID, params[0], true)
 
 	if jsonResponse.String() != `{"jsonrpc":"2.0","id":53,"result":"0xc8"}` {
@@ -170,7 +171,7 @@ func TestGetTransactionCountPendingNoValue(t *testing.T) {
 	relayHubAddress := common.HexToAddress("0xdD37c69fF29C4b93A346Ed6dF184f48A71800b7E")
 	relaySignerService.Config.Application.RelayHubContractAddress = &relayHubAddress
 	relaySignerService.Config.Application.ContractAddress = "0xdD37c69fF29C4b93A346Ed6dF184f48A71800b7E"
-	relaySignerService.senders = make(map[string]*big.Int)
+	relaySignerService.senders = make(map[string]*nonceEntry)
 	jsonResponse := relaySignerService.GetTransactionCount(rpcMessage.ID, params[0], true)
 
 	if jsonResponse.String() != `{"jsonrpc":"2.0","id":53,"result":"0x159"}` {
@@ -355,6 +356,9 @@ func TestNonceAfterTransactions(t *testing.T) {
 
 	sender := "0x92c9885663f6e84127c857d3137936c424b7e07555d2bc7d8bd781b3f0847ac8"
 
+	// Tras relayar una tx firmada con nonce=i, la lectura "pending" debe devolver el PRÓXIMO
+	// nonce a usar (i+1) — no el recién consumido (comportamiento antiguo, que provocaba colisión
+	// inmediata del siguiente envío).
 	for i := 34; i < 45; i++ {
 		jsonResponse := relaySignerService.SendMetatransaction(rpcMessage.ID, &to, gasLimit, encodedFunction, 27, r, s, sender, uint64(i))
 		if jsonResponse.String() != `{"jsonrpc":"2.0","id":2914410858336929,"result":"0x9c2fb4956ce18491021a534106fe50e7cfe86bcc373b1626623fa0366f4cc3bc"}` {
@@ -363,16 +367,10 @@ func TestNonceAfterTransactions(t *testing.T) {
 
 		jsonResponseNonce := relaySignerService.GetTransactionCount(rpcMessage.ID, sender, true)
 
-		fmt.Println(jsonResponseNonce)
-
-		nonce := fmt.Sprintf("%x", i)
-
-		fmt.Println(nonce)
-
-		responseNonce := fmt.Sprintf(`{"jsonrpc":"2.0","id":2914410858336929,"result":"0x%s"}`, nonce)
+		responseNonce := fmt.Sprintf(`{"jsonrpc":"2.0","id":2914410858336929,"result":"0x%x"}`, i+1)
 
 		if jsonResponseNonce.String() != responseNonce {
-			t.Errorf("Incorrect nonce was gotten")
+			t.Errorf("Incorrect nonce was gotten: %s, expected %s", jsonResponseNonce.String(), responseNonce)
 		}
 	}
 
@@ -380,6 +378,103 @@ func TestNonceAfterTransactions(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+// Dos envíos que firmaron el MISMO nonce (colisión concurrente) solo pueden consumir uno on-chain:
+// el caché debe quedar en nonce+1, no avanzar +1 por cada envío (eso lo dejaba por delante del real
+// para siempre → BadNonce permanente para esa address).
+func TestNonceCollisionDoesNotDoubleIncrement(t *testing.T) {
+	service := new(RelaySignerService)
+	service.Config = &model.Config{}
+	service.senders = make(map[string]*nonceEntry)
+
+	sender := "0xa0f03c489a1bcd53883289d3c476100220b21b0b"
+	service.incrementTransactionCount(sender, 23)
+	service.incrementTransactionCount(sender, 23) // colisión: mismo nonce firmado
+
+	next, ok := service.cachedNonce(sender)
+	if !ok || next != 24 {
+		t.Errorf("expected cached nonce 24 after collision, got %d (ok=%v)", next, ok)
+	}
+}
+
+// Al detectar BadTransactionSent la entrada del sender debe borrarse: la próxima lectura "pending"
+// vuelve al nonce real on-chain.
+func TestInvalidateNonce(t *testing.T) {
+	service := new(RelaySignerService)
+	service.Config = &model.Config{}
+	service.senders = make(map[string]*nonceEntry)
+
+	sender := "0xa0f03c489a1bcd53883289d3c476100220b21b0b"
+	service.incrementTransactionCount(sender, 10)
+	if _, ok := service.cachedNonce(sender); !ok {
+		t.Fatal("expected cache entry before invalidation")
+	}
+
+	// como llega desde el evento: address en checksum EIP-55
+	service.invalidateNonce(common.HexToAddress(sender).Hex())
+
+	if _, ok := service.cachedNonce(sender); ok {
+		t.Error("expected cache entry to be removed after invalidateNonce")
+	}
+}
+
+// Una entrada más vieja que el TTL debe descartarse (fallback on-chain) en lectura y no ancla el
+// incremento siguiente.
+func TestNonceCacheTTLExpiry(t *testing.T) {
+	service := new(RelaySignerService)
+	service.Config = &model.Config{}
+	service.Config.Application.NonceCacheTTL = 1 // 1s para el test
+	service.senders = make(map[string]*nonceEntry)
+
+	sender := "0xa0f03c489a1bcd53883289d3c476100220b21b0b"
+	service.senders[sender] = &nonceEntry{next: 99, updatedAt: time.Now().Add(-2 * time.Second)}
+
+	if _, ok := service.cachedNonce(sender); ok {
+		t.Error("expected expired entry to be discarded")
+	}
+
+	// tras expirar, el incremento re-siembra desde el nonce firmado (no desde la entrada vieja)
+	service.senders[sender] = &nonceEntry{next: 99, updatedAt: time.Now().Add(-2 * time.Second)}
+	service.incrementTransactionCount(sender, 5)
+	next, ok := service.cachedNonce(sender)
+	if !ok || next != 6 {
+		t.Errorf("expected cached nonce 6 after expired entry reseed, got %d (ok=%v)", next, ok)
+	}
+}
+
+// La misma address en lowercase (lecturas de ethers) y en checksum EIP-55 (escritura interna,
+// message.From().Hex()) debe caer en la MISMA entrada del caché.
+func TestNonceKeyCaseInsensitive(t *testing.T) {
+	service := new(RelaySignerService)
+	service.Config = &model.Config{}
+	service.senders = make(map[string]*nonceEntry)
+
+	checksum := "0xA0F03C489a1bcd53883289d3c476100220b21B0b"
+	lower := "0xa0f03c489a1bcd53883289d3c476100220b21b0b"
+
+	service.incrementTransactionCount(checksum, 7)
+	next, ok := service.cachedNonce(lower)
+	if !ok || next != 8 {
+		t.Errorf("expected cached nonce 8 via lowercase key, got %d (ok=%v)", next, ok)
+	}
+}
+
+// Accesos concurrentes al caché no deben corromperlo ni disparar el detector de carreras (-race).
+func TestNonceCacheConcurrentAccess(t *testing.T) {
+	service := new(RelaySignerService)
+	service.Config = &model.Config{}
+	service.senders = make(map[string]*nonceEntry)
+
+	sender := "0xa0f03c489a1bcd53883289d3c476100220b21b0b"
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func(n uint64) { defer wg.Done(); service.incrementTransactionCount(sender, n) }(uint64(i))
+		go func() { defer wg.Done(); service.cachedNonce(sender) }()
+		go func() { defer wg.Done(); service.invalidateNonce(sender) }()
+	}
+	wg.Wait()
 }
 
 func serverMock() *httptest.Server {


### PR DESCRIPTION
## Problema

Al enviar 2 tx en paralelo desde la misma address vía el relay, una gana y la otra sale `BadTransactionSent(BadNonce)` — esperado. El bug: **después, esa address queda bloqueada permanentemente** (todo reintento vuelve a dar BadNonce) hasta reiniciar el relay-signer. Reportado en producción y reproducido en vivo en el nodo dev (2026-07-08).

## Causa raíz

El caché en memoria `senders` (próximo nonce por sender, `service/relaySignerService.go`) que responde `eth_getTransactionCount(addr, "pending")` tenía cuatro defectos:

1. **+1 incondicional por cada envío aceptado por besu** (antes de conocer el resultado on-chain): una colisión avanza el caché +2 pero el RelayHub solo avanza +1 → el caché queda por delante del nonce real y **cada reintento fallido lo aleja +1 más**, sin ninguna vía de corrección (no existía delete/decremento/TTL).
2. **Seed off-by-one**: la primera entrada guardaba el nonce recién usado en vez del próximo (`nonce+1`).
3. **Clave sin normalizar**: la lectura usa la string cruda del cliente (ethers manda lowercase) y la escritura usa `message.From().Hex()` (checksum EIP-55) → entradas duplicadas con estados distintos según el case que use el cliente.
4. **Sin mutex** sobre el mapa (data race entre goroutines HTTP).

Evidencia pre-fix (script de repro, caché vs `getNonce(from)` on-chain):

```
[antes]   pending checksum=27 | real=27   OK
2 tx paralelas → tx#A OK · tx#B BadNonce
[después] pending checksum=29 | real=28   DESINCRONIZADO
reintento firma 29 → BadNonce → checksum=30 | real=28
reintento firma 30 → BadNonce → checksum=31 | real=28   (crece +1 por intento)
```

## Fix

- **Invalidación al detectar `BadTransactionSent`** en `GetTransactionReceipt` / `GetMetaTxResult`: se borra la entrada del `originalSender` → la próxima lectura `pending` vuelve al `getNonce(from)` real on-chain (la address se auto-repara al leer el receipt de la tx perdedora).
- `incrementTransactionCount`: `próximo = max(nonce_firmado+1, cacheado)` — una colisión ya no doble-incrementa.
- Seed correcto: `nonce+1`.
- **TTL de respaldo** (config `nonceCacheTTL` en segundos, default 300): cubre al cliente que nunca consulta el receipt, eventos perdidos o WS caído.
- Clave normalizada a lowercase + `sync.Mutex` dedicado.

La colisión inicial entre 2 tx paralelas es inherente al diseño (nonce secuencial exacto en `TxRelay`); lo que elimina este PR es el **atasco permanente** posterior.

## Verificación

- `go test ./... -race` en verde; tests nuevos: colisión sin doble incremento, invalidación, expiración TTL, case-insensitive, acceso concurrente. `TestNonceAfterTransactions` actualizado a la semántica correcta (tras enviar nonce `i`, `pending` devuelve `i+1`).
- **Verificado en vivo en el nodo dev** (build `v1.0.1-14-g3b833bf`): tras la colisión el caché queda sincronizado y los envíos siguientes salen OK sin reiniciar el servicio; flujo normal (transfer OK) sin regresión.
- Repro: `samples-error-tx-gas-model/scripts/10-bad-nonce-concurrent.js` (compara pending lowercase/checksum vía relay contra el `getNonce` real de la implementación).

## Actualización 2026-07-08 — verificación adicional en vivo

Nueva corrida completa del repro contra el dev con el fix desplegado, partiendo de estado sincronizado (38/38/38). El script ahora emite un **veredicto calculado** del resultado (commit `7a1a1d4` de samples-error-tx-gas-model) en vez de un texto fijo:

```
2 tx paralelas → tx#A OK · tx#B BadTransactionSent: BadNonce   (colisión inherente)
[después]  pending lower=39 checksum=39 | on-chain real=39   OK (coinciden)
seq#1 firma 39 (lo que sirve el relay) → status=1 OK
seq#2 firma 40                          → status=1 OK
control (nonce on-chain)                → status=1 OK

== Veredicto ==
✅ SIN ATASCO: tras la colisión el caché quedó sincronizado con el nonce real (42)
   y los 2/2 reintentos secuenciales salieron OK sin reiniciar el servicio.
```

Pre-fix, la misma secuencia dejaba el caché en `checksum=31 | real=28` (desfase +3 y creciendo) y todos los reintentos fallaban con `BadNonce` hasta reiniciar el proceso.
